### PR TITLE
Travis CI Pro fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ then on whenever the "status" of the project repository changes. The handling of
 these events was borrowed from the `git-view.coffee` part of the `status-bar`
 package.
 
+### Remote Name
+
+If the remote repository Travis is configured to build is named something other
+than `origin`, you can specify a different name in the **Travis Ci Remote Name**
+field in the settings view.
+
 ### Travis Pro
 
 You are able to use this with Travis Pro if you enable it in the settings view.

--- a/lib/build-matrix-view.coffee
+++ b/lib/build-matrix-view.coffee
@@ -88,9 +88,14 @@ class BuildMatrixView extends View
 
     duration = ((finished - started) / 1000).toString()
 
+    domain = if atom.travis.pro
+      'magnum.travis-ci.com'
+    else
+      'travis-ci.org'
+
     @builds.append("""
       <li class='#{status}'>
         #{build['number']} - #{duration.formattedDuration()}
-        (<a target="_new" href="https://travis-ci.org/#{@nwo}/builds/#{build['build_id']}">details</a>)
+        (<a target="_new" href="https://#{domain}/#{@nwo}/builds/#{build['build_id']}">details</a>)
       </li>
     """)

--- a/lib/build-status-view.coffee
+++ b/lib/build-status-view.coffee
@@ -69,7 +69,8 @@ class BuildStatusView extends View
 
     repos = atom.project.getRepositories()
     console.log "DEBUG:", repos
-    repo = repos.filter((r) -> /(.)*github\.com/i.test(r.getOriginURL()))
+    name = atom.config.get('travis-ci-status.travisCiRemoteName')
+    repo = repos.filter((r) -> /(.)*github\.com/i.test(r.getConfigValue("remote.#{name}.url")))
     @repo = repo[0]
 
     $(@repo).on 'status-changed', (path, status) =>

--- a/lib/travis-ci-status.coffee
+++ b/lib/travis-ci-status.coffee
@@ -16,6 +16,9 @@ module.exports =
     personalAccessToken:
         type: 'string'
         default: '<Your personal GitHub access token>'
+    travisCiRemoteName:
+        type: 'string'
+        default: 'origin'
 
   # Internal: The build matrix bottom panel view.
   buildMatrixView: null
@@ -55,9 +58,9 @@ module.exports =
   # Returns true if the repository has a GitHub remote, else false
   hasGitHubRepo: (repos) ->
     return false if repos.length is 0
-
+    name = atom.config.get('travis-ci-status.travisCiRemoteName')
     for repo in repos
-      return true if /(.)*github\.com/i.test(repo.getOriginURL())
+      return true if /(.)*github\.com/i.test(repo.getConfigValue("remote.#{name}.url"))
 
     false
 
@@ -67,7 +70,8 @@ module.exports =
   # exist.
   getNameWithOwner: ->
     repo = atom.project.getRepositories()[0]
-    url  = repo.getOriginURL()
+    name = atom.config.get('travis-ci-status.travisCiRemoteName')
+    url  = repo.getConfigValue("remote.#{name}.url")
 
     return null unless url?
 

--- a/spec/travis-ci-status-spec.coffee
+++ b/spec/travis-ci-status-spec.coffee
@@ -15,7 +15,7 @@ describe "TravisCiStatus", ->
   describe "when the travis-ci-status:toggle event is triggered", ->
     beforeEach ->
       spyOn(atom.project, "getRepositories").andReturn([{
-        getOriginURL: ->
+        getConfigValue: (name) ->
           "git@github.com:test/test.git"
       }])
 
@@ -31,7 +31,7 @@ describe "TravisCiStatus", ->
   describe "can get the nwo if the project is a github repo", ->
     it "gets nwo of https repo ending in .git", ->
       spyOn(atom.project, "getRepositories").andReturn([{
-        getOriginURL: ->
+        getConfigValue: (name) ->
           "https://github.com/tombell/travis-ci-status.git"
       }])
 
@@ -40,7 +40,7 @@ describe "TravisCiStatus", ->
 
     it "gets nwo of https repo not ending in .git", ->
       spyOn(atom.project, "getRepositories").andReturn([{
-        getOriginURL: ->
+        getConfigValue: (name) ->
           "https://github.com/tombell/test-status"
       }])
 
@@ -49,7 +49,7 @@ describe "TravisCiStatus", ->
 
     it "gets nwo of ssh repo ending in .git", ->
       spyOn(atom.project, "getRepositories").andReturn([{
-        getOriginURL: ->
+        getConfigValue: (name) ->
           "git@github.com:tombell/travis-ci-status.git"
       }])
 
@@ -58,7 +58,7 @@ describe "TravisCiStatus", ->
 
     it "gets nwo of ssh repo not ending in .git", ->
       spyOn(atom.project, "getRepositories").andReturn([{
-        getOriginURL: ->
+        getConfigValue: (name) ->
           "git@github.com:tombell/test-status"
       }])
 


### PR DESCRIPTION
Fixed url that always resolved to the non-pro version of Travis. Added setting to check for Travis builds on remotes with names other than `origin`. See commit message details for more information.