### PR TITLE
Update status bar screenshot to use absolute link for Atom docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add Travis CI status of the project to the Atom status bar.
 
-![Atom Status Bar Screenshot](travis_ci_status.png)
+![Atom Status Bar Screenshot](https://raw.githubusercontent.com/tombell/travis-ci-status/master/travis_ci_status.png)
 
 ## Installing
 


### PR DESCRIPTION
Fix issue #69