### PR TITLE
Fix: Cannot read property 'getConfigValue' of null

### DIFF
--- a/lib/travis-ci-status.coffee
+++ b/lib/travis-ci-status.coffee
@@ -36,6 +36,7 @@ module.exports =
         atom.project.repositoryForDirectory.bind(atom.project)
       )
     ).then (repos) =>
+      repos = repos.filter (repo) -> repo
       new Promise((resolve) =>
         if @hasGitHubRepo(repos)
           @isTravisProject((config) ->


### PR DESCRIPTION
Fix an error that get's thrown, when opening a directory without a git repository.

![screen shot 2015-10-07 at 23 07 04](https://cloud.githubusercontent.com/assets/423234/10351245/c00597c4-6d48-11e5-9923-2a9869b1548f.png)
