### PR TITLE
Check for Travis repos when the project path changes.

### DIFF
--- a/lib/travis-ci-status.coffee
+++ b/lib/travis-ci-status.coffee
@@ -31,6 +31,12 @@ module.exports =
   #
   # Returns nothing.
   activate: ->
+    @projectChangeSubscription = atom.project.onDidChangePaths =>
+      @checkTravisRepos().then => @init(@statusBar)
+
+    @checkTravisRepos()
+
+  checkTravisRepos: ->
     @activationPromise = Promise.all(
       atom.project.getDirectories().map(
         atom.project.repositoryForDirectory.bind(atom.project)
@@ -129,6 +135,7 @@ module.exports =
     shell.openExternal("https://#{domain}/#{nwo}")
 
   consumeStatusBar: (statusBar) ->
+    @statusBar = statusBar
     @activationPromise.then( => @init(statusBar))
     @statusBarSubscription = new Disposable =>
       @buildStatusView?.destroy()

--- a/lib/travis-ci-status.coffee
+++ b/lib/travis-ci-status.coffee
@@ -57,6 +57,7 @@ module.exports =
     atom.travis = null
     @statusBarSubscription?.dispose()
     @buildMatrixView?.destroy()
+    @projectChangeSubscription?.dispose()
 
   # Internal: Serialize each view state so it can be restored when activated.
   #


### PR DESCRIPTION
Almost a year to the day, I got around to fixing that bug I'd whined about in #59! This updates the `activate` method so that it subscribes to `atom.project.onDidChangePaths` and belatedly activates the status bar item for the new project path.