### PR TITLE
Use new Electron require syntax

### DIFF
--- a/lib/travis-ci-status.coffee
+++ b/lib/travis-ci-status.coffee
@@ -1,6 +1,6 @@
 fs = require 'fs'
 path = require 'path'
-shell = require 'shell'
+{shell} = require 'electron'
 {Disposable} = require 'atom'
 
 TravisCi = null


### PR DESCRIPTION
Self-explanatory: all modules are now located under `electron`.  Directly requiring them is deprecated.

Fixes #81.