### PR TITLE
travisCiAltRemotes configuration and parsing fixes

### DIFF
--- a/lib/travis-ci-status.coffee
+++ b/lib/travis-ci-status.coffee
@@ -117,11 +117,16 @@ module.exports =
       gitPath = /([^\/:]+)\/([^\/]+)$/.exec(url.replace(/\.git$/, ''))[0]
 
       name = atom.config.get('travis-ci-status.travisCiRemoteName')
-      override = atom.config.get('travis-ci-status.travisCiAltRemotes')
-      override = JSON.parse(override)
+      override = atom.config.get('travis-ci-status.travisCiAltRemotes') || "{}"
 
-      if override.hasOwnProperty(gitPath)
-        name = override[gitPath]
+      if override?
+        try
+          override = JSON.parse(override)
+        catch
+          override = {}
+
+        if override.hasOwnProperty(gitPath)
+          name = override[gitPath]
 
       name
 

--- a/spec/travis-ci-status-spec.coffee
+++ b/spec/travis-ci-status-spec.coffee
@@ -2,12 +2,16 @@ TravisCiStatus = require '../lib/travis-ci-status'
 
 describe "TravisCiStatus", ->
   workspaceElement = null
+  gitPath = "tombell/travis-ci-status"
+  repoURL = "https://github.com/#{gitPath}.git"
+  defaultRemote = "origin"
 
   beforeEach ->
     waitsForPromise ->
       atom.packages.activatePackage('status-bar')
 
     spyOn(TravisCiStatus, "isTravisProject").andCallFake((cb) -> cb(true))
+    atom.config.set('travis-ci-status.travisCiRemoteName', defaultRemote)
 
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
@@ -27,6 +31,46 @@ describe "TravisCiStatus", ->
 
       runs ->
         expect(workspaceElement.querySelector(".travis-ci-status")).toExist()
+
+  describe "gets final remote name", ->
+    gitPath =
+    repo =
+      getConfigValue: (name) ->
+        repoURL
+      getOriginURL: ->
+        repoURL
+
+    it "uses atom default if no repo provided", ->
+      spyOn(atom.project, "getRepositories").andReturn([repo])
+      atom.config.set('travis-ci-status.travisCiAltRemotes', '{}')
+      remote = TravisCiStatus.getFinalRemote(null)
+      expect(remote).toEqual(defaultRemote)
+
+    it "uses default remote if invalid JSON override", ->
+      spyOn(atom.project, "getRepositories").andReturn([repo])
+      atom.config.set('travis-ci-status.travisCiAltRemotes', 'invalid JSON')
+      remote = TravisCiStatus.getFinalRemote(null)
+      expect(remote).toEqual(defaultRemote)
+
+      atom.config.set('travis-ci-status.travisCiAltRemotes', undefined)
+      remote = TravisCiStatus.getFinalRemote(null)
+      expect(remote).toEqual(defaultRemote)
+
+    it "uses default remote if override doesn't match gitPath", ->
+      spyOn(atom.project, "getRepositories").andReturn([repo])
+      atom.config.set('travis-ci-status.travisCiAltRemotes', '{"another-user/their-repo": "staging"}')
+      remote = TravisCiStatus.getFinalRemote(null)
+      expect(remote).toEqual(defaultRemote)
+
+    it "uses override remote if matches gitPath", ->
+      spyOn(atom.project, "getRepositories").andReturn([repo])
+      atom.config.set('travis-ci-status.travisCiAltRemotes', '{"tombell/travis-ci-status": "staging"}')
+      remote = TravisCiStatus.getFinalRemote(null)
+      expect(remote).toEqual("staging")
+
+    it "returns undefined if no repo found", ->
+      remote = TravisCiStatus.getFinalRemote(null)
+      expect(remote).toBeUndefined()
 
   describe "can get the nwo if the project is a github repo", ->
     it "gets nwo of https repo ending in .git", ->


### PR DESCRIPTION
## Fix

Adding this package on a fresh Atom install wasn't working out of the box for me. After looking into things further I was able to see an issue with the remote override parsing. When no overrides are set the defaults are not JSON parseable and thus throws the error seen in #88. If you set the `travisCiAltRemotes` setting to an empty `{}` then things will work. Doing a _real override_ appeared to work as expected. 

The changes introduced here check for valid JSON override strings. If it is empty or invalid then the default `origin` will be used. I added passing specs for the change, although, the other specs appear to currently be failing.
## Changes
- Default empty override to a JSON parseable string
- Guard override from bad JSON
- Only set override if parsed and matches `gitPath`
- Default the remote to origin
- Add tests around override parsing logic

I think this fixes #88 
